### PR TITLE
Patch for Powerline

### DIFF
--- a/ricty.rb
+++ b/ricty.rb
@@ -15,7 +15,7 @@ class Migu1MFonts < Formula
 end
 
 class Powerline < Formula
-  homepage 'https://github.com/Lokaltog/vim-powerline'
+  homepage 'https://github.com/Lokaltog/powerline'
   url 'https://github.com/Lokaltog/powerline/archive/db80fc95ed.tar.gz'
   sha1 '00c8911bce9ad9eab72ff1b366bc4ea417404724'
   version '20130827'


### PR DESCRIPTION
Powerline というものを使うのにフォントにパッチを当てる必要があるらしいので、 `brew install --powerline ricty` でパッチが当たるようにしてみました。

「[Powerline の方のパッチではなぜかうまく出来なかったので、 vim-powerline の方で行っている。](http://yuyunko.bitbucket.org/blog/html/2013/09/14/ricty_powerline_install.html)」という話もあったので、 `--vim-powerline` オプションも付けています。

生成されるファイルが `--powerline` は `Ricty Bold for Powerline.ttf`, `Ricty Discord Bold for Powerline.ttf`, `Ricty Discord Regular for Powerline.ttf`, `Ricty Regular for Powerline.ttf` で、 `--vim-powerline` が `Ricty-Bold-Powerline.ttf`, `Ricty-Regular-Powerline.ttf`, `RictyDiscord-Bold-Powerline.ttf`, `RictyDiscord-Regular-Powerline.ttf` で衝突しなかったため、同時に指定できるようにしています。
