### PR TITLE
Fix failure during powerline font patching

### DIFF
--- a/ricty.rb
+++ b/ricty.rb
@@ -49,7 +49,7 @@ class Ricty < Formula
   option "disable-visible-space", "Disable visible zenkaku space"
   option "patch-in-place", "Patch Powerline glyphs directly into Ricty fonts without creating new 'for Powerline' fonts"
 
-  depends_on 'fontforge'
+  depends_on 'fontforge' => 'with-python'
 
   def install
     share_fonts = share+'fonts'


### PR DESCRIPTION
Since commit Homebrew/homebrew@0b50110, fontforge keg is installed without Python extension by default. 
Thus, this keg fails during powerline font [patching process](https://github.com/sanemat/homebrew-font/blob/1d196b1fa9b19862f6f9c64d7ffa751cbead4442/ricty.rb#L92). This pull request adds '--with-python' option to font forge build, which forces to build fontforge with Python extension enabled.
