### PR TITLE
join powerlin_args

### DIFF
--- a/ricty.rb
+++ b/ricty.rb
@@ -89,7 +89,7 @@ class Ricty < Formula
     if build.include? "powerline" or build.include? "vim-powerline"
       powerline_script.each do |script|
         ttf_files.each do |ttf|
-          system "fontforge -lang=py -script #{script} #{powerline_args} #{ttf}"
+          system "fontforge -lang=py -script #{script} #{powerline_args.join(' ')} #{ttf}"
           mv ttf.gsub(/#{rename_from}/,rename_to), ttf if build.include? "patch-in-place"
         end
       end


### PR DESCRIPTION
fix problem shown below:

```
==> fontforge -lang=py -script /private/tmp/ricty-1xeZ/Ricty-3.2.3/scripts/powerline-fontpatcher [] Ricty-Bold.ttf
 Executable based on sources from 14:57 GMT 31-Jul-2012-D.
 Library based on sources from 14:57 GMT 31-Jul-2012.
usage: powerline-fontpatcher [-h] [--no-rename] [--source-font font]
                             font [font ...]
powerline-fontpatcher: error: argument font: can't open '[]': [Errno 2] No such file or directory: '[]'
```
