### PR TITLE
Hot fix, levien.com is missing

### DIFF
--- a/ricty.rb
+++ b/ricty.rb
@@ -2,7 +2,9 @@ require 'formula'
 
 class InconsolataFonts < Formula
   homepage 'http://levien.com/type/myfonts/inconsolata.html'
-  url 'http://levien.com/type/myfonts/Inconsolata.otf'
+  # url 'http://levien.com/type/myfonts/Inconsolata.otf'
+  # Hot fix, levien.com is missing
+  url 'http://dbg.download.sourcemage.org/mirror/Inconsolata.otf'
   sha1 '7f0a4919d91edcef0af9dc153054ec49d1ab3072'
   version '1.0.0'
 end


### PR DESCRIPTION
Download `Inconsolata.otf` from `dbg.download.sourcemage.org` instead of original `levien.com`.
fixes #18 
