### PR TITLE
Patch Discord script to support Inconsolata-dz

### DIFF
--- a/ricty.rb
+++ b/ricty.rb
@@ -70,6 +70,9 @@ class Ricty < Formula
     if build.include? 'dz'
       resource('inconsolatadzfonts').stage { share_fonts.install Dir['*'] }
       inconsolata = share_fonts + 'Inconsolata-dz.otf'
+      # Patch the discord script since the special characters are in different locations in Inconsolata-dz
+      inreplace 'ricty_discord_patch.pe', '65608', '65543' # Serif r
+      inreplace 'ricty_discord_patch.pe', '65610', '65545' # Un-dotted zero
     else
       resource('inconsolatafonts').stage { share_fonts.install Dir['*'] }
       inconsolata = share_fonts + 'Inconsolata.otf'


### PR DESCRIPTION
Inconsolata and Inconsolata-dz have alternate characters at the end of
the font that `ricty_discord_patch.pe` copies into the ASCII range by
default. However, the alternate characters are at different locations in
each font and the Ricty Discord patch assumes Inconsolata, so it copies
the wrong characters when Inconsolata-dz is used.

This change adds a patch (replacement) to `ricty_discord_patch.pe` to
work around the Ricty issue and manually specify the code points for the
alternate characters in Inconsolata-dz.

Fixes #17