### PR TITLE
calling `patch` method explicitly

### DIFF
--- a/ricty.rb
+++ b/ricty.rb
@@ -5,7 +5,7 @@ class Powerline < Formula
   url 'https://github.com/powerline/fontpatcher/archive/18a788b8ec1822095813b73b0582a096320ff714.zip'
   sha1 'eacbca3a3e3b7acd03743e80a51de97c9c0bbc80'
   version '20150113'
-  def initialize(name = 'powerline', path = self.class.path(name), spec = 'stable')
+  def initialize(name = 'powerline', path = Pathname(__FILE__), spec = 'stable')
     super
   end
   patch :DATA
@@ -56,7 +56,9 @@ class Ricty < Formula
 
     resource('migu1mfonts').stage { share_fonts.install Dir['*'] }
     if build.include? 'powerline'
-      Powerline.new.brew { buildpath.install Dir['*'] }
+      powerline = Powerline.new
+      powerline.brew { buildpath.install Dir['*'] }
+      powerline.patch
       powerline_script << buildpath + 'scripts/powerline-fontpatcher'
       rename_from = '(Ricty|Discord)-?'
       rename_to = "\\1 "


### PR DESCRIPTION
久々に利用させていただいたところ、powerline へのパッチが当たらなくなっていました。調べたところ、以前は `brew` メソッドの中で `patch` メソッドが呼ばれていたのですが、[このコミット][]によりその辺のロジックが変わってしまったようです。

[このコミット]: https://github.com/Homebrew/homebrew/commit/b76e26c9cf1fc805663d86b6d6d081f91f73ea18

Homebrew way 的にどうなのかはわかりませんが、とりあえず明示的に `patch` メソッドを呼ぶようにしたところ、これが改善されました。