### PR TITLE
Update Ricty to version 4.0.1

### DIFF
--- a/ricty.rb
+++ b/ricty.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Powerline < Formula
   homepage 'https://github.com/powerline/fontpatcher'
   url 'https://github.com/powerline/fontpatcher/archive/18a788b8ec1822095813b73b0582a096320ff714.zip'
-  sha1 '08cbd82a0b058af4ed2e03cd0ed2fbcf1f14a0c3'
+  sha256 'c50a9c9a94e7b5a3f0cd0c149c5c394684c8b9b63e049a9277500286921c29ce'
   version '20150113'
   def initialize(name = 'powerline', path = Pathname(__FILE__), spec = 'stable')
     super
@@ -13,37 +13,36 @@ end
 
 class Ricty < Formula
   homepage 'https://github.com/yascentur/Ricty'
-  url 'https://github.com/yascentur/Ricty/archive/3.2.4.tar.gz'
-  sha1 '7fc8adcc74656d9e2e1acd325de82f0f08a6d222'
-  version '3.2.4'
+  url 'https://github.com/yascentur/Ricty/archive/4.0.1.zip'
+  sha256 'c4997623a59a62ebe6a1a83a4deec24db0dc85faa73a2b0512c73a022e931161'
+  version '4.0.1'
 
-  resource 'inconsolatafonts' do
-    url 'http://levien.com/type/myfonts/Inconsolata.otf'
-    sha1 '7f0a4919d91edcef0af9dc153054ec49d1ab3072'
+  resource 'inconsolataregular' do
+    url 'https://github.com/google/fonts/raw/master/ofl/inconsolata/Inconsolata-Regular.ttf'
+    sha256 '346eff8b8292ef2b8026cf1dbea3fc0c79eba444270d38d73da895ddcba74e15'
     version '1.0.0'
   end
 
-  resource 'inconsolatadzfonts' do
-    url 'http://media.nodnod.net/Inconsolata-dz.otf.zip'
-    sha1 'c8254dbed67fb134d4747a7f41095cedab33b879'
+  resource 'inconsolatabold' do
+    url 'https://github.com/google/fonts/raw/master/ofl/inconsolata/Inconsolata-Bold.ttf'
+    sha256 '0db9dc0cf39efef147a7b368c98e1b7588afd2bc4d30e4c9e313f5511e599a87'
     version '1.0.0'
   end
 
   resource 'migu1mfonts' do
-    url 'http://sourceforge.jp/frs/redir.php?m=iij&f=%2Fmix-mplus-ipa%2F59022%2Fmigu-1m-20130617.zip'
-    sha1 'a0641894cec593f8bb1e5c2bf630f20ee9746b18'
-    version '20130617'
+    url 'https://osdn.jp/frs/redir.php?m=gigenet&f=%2Fmix-mplus-ipa%2F63545%2Fmigu-1m-20150712.zip'
+    sha256 'd4c38664dd57bc5927abe8f4fbea8f06a8ece3fea49ea02354d4e03ac6d15006'
+    version '20150712'
   end
 
   resource 'vimpowerline' do
     url 'https://github.com/Lokaltog/vim-powerline/archive/09c0cea859.tar.gz'
-    sha1 'a1acef16074b6c007a57de979787a9b166f1feb1'
+    sha256 'dde995aaf8e7f4a8d9ea3a9d34e55d760e4979314ff8c1bf0f6e25caf606b3b0'
     version '20120817'
   end
 
   option 'powerline', 'Patch for Powerline'
   option 'vim-powerline', 'Patch for Powerline from vim-powerline'
-  option 'dz', 'Use Inconsolata-dz instead of Inconsolata'
   option 'disable-fullwidth', 'Disable fullwidth ambiguous characters'
   option 'disable-visible-space', 'Disable visible zenkaku space'
   option 'patch-in-place', "Patch Powerline glyphs directly into Ricty fonts without creating new 'for Powerline' fonts"
@@ -69,18 +68,12 @@ class Ricty < Formula
       rename_from = "\.ttf"
       rename_to = '-Powerline.ttf'
     end
-    if build.include? 'dz'
-      resource('inconsolatadzfonts').stage { share_fonts.install Dir['*'] }
-      inconsolata = share_fonts + 'Inconsolata-dz.otf'
-      # Patch the discord script since the special characters are in different locations in Inconsolata-dz
-      inreplace 'ricty_discord_patch.pe', '65608', '65543' # Serif r
-      inreplace 'ricty_discord_patch.pe', '65610', '65545' # Un-dotted zero
-    else
-      resource('inconsolatafonts').stage { share_fonts.install Dir['*'] }
-      inconsolata = share_fonts + 'Inconsolata.otf'
-    end
+    resource('inconsolataregular').stage { share_fonts.install Dir['*'] }
+    inconsolataregularttf = share_fonts + 'Inconsolata-Regular.ttf'
+    resource('inconsolatabold').stage { share_fonts.install Dir['*'] }
+    inconsolataboldttf = share_fonts + 'Inconsolata-Bold.ttf'
 
-    ricty_args = [inconsolata, share_fonts + 'migu-1m-regular.ttf', share_fonts + 'migu-1m-bold.ttf']
+    ricty_args = [inconsolataregularttf, inconsolataboldttf, share_fonts + 'migu-1m-regular.ttf', share_fonts + 'migu-1m-bold.ttf']
     ricty_args.unshift('-z') if build.include? 'disable-visible-space'
     ricty_args.unshift('-a') if build.include? 'disable-fullwidth'
 


### PR DESCRIPTION
Removes support for Inconsolata-dz since Ricty now uses the new TTF
version of Inconsolata, which doesn’t seem to have a dz variant.

Also updates all sha1 hashes to sha256.

Fixes #35.